### PR TITLE
Update requirements and enhance setup.py for flexible pip installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ accelerate==0.32.0
 datasets==2.17.1
 lm-eval==0.4.9.1
 termcolor
-triton==3.0.0
+triton>=3.2.0
 
 ## for plot flatness
 matplotlib


### PR DESCRIPTION
Proposed fix for the issue with pip install inside another repo: https://github.com/ruikangliu/FlatQuant/issues/31
Addresses 2 main issues:

1. Adds `third_party_cmake()` BUILD_ARGS
2. Adds package names to `setup()` allowing for installing flatquant as pip package, as well as building internal `deploy` package with kernels.